### PR TITLE
Fixes to compile with GHC 7.8

### DIFF
--- a/src/Data/PropertyList/Binary/Float.hs
+++ b/src/Data/PropertyList/Binary/Float.hs
@@ -11,6 +11,7 @@ module Data.PropertyList.Binary.Float
 
 import Foreign
 import GHC.Float
+import System.IO.Unsafe (unsafePerformIO)
 
 -- TODO: create a library or extend an existing one to include a module Data.Float.IEEE
 -- which exports types Float32, Float64, etc., with proper IEEE-safe conversions

--- a/src/Data/PropertyList/Types.hs
+++ b/src/Data/PropertyList/Types.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE 
     MultiParamTypeClasses,
     FlexibleContexts, FlexibleInstances,
-    GeneralizedNewtypeDeriving, TypeFamilies
+    GeneralizedNewtypeDeriving, TypeFamilies,
+    DeriveTraversable
   #-}
 
 -- |This module implements the 'PropertyList' and 'PartialPropertyList' types


### PR DESCRIPTION
With these, as well as a fix to `recursion-schemes` (https://github.com/ekmett/recursion-schemes/issues/6), the package builds on GHC 7.8.
