### PR TITLE
Fix for GHC 7.6 (broke with 7.8 patch)

### DIFF
--- a/src/Data/PropertyList/Binary/Float.hs
+++ b/src/Data/PropertyList/Binary/Float.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 module Data.PropertyList.Binary.Float
     ( doubleToWord64
     , word64ToDouble
@@ -11,7 +11,9 @@ module Data.PropertyList.Binary.Float
 
 import Foreign
 import GHC.Float
+#if MIN_VERSION_base(4,7,0)
 import System.IO.Unsafe (unsafePerformIO)
+#endif
 
 -- TODO: create a library or extend an existing one to include a module Data.Float.IEEE
 -- which exports types Float32, Float64, etc., with proper IEEE-safe conversions


### PR DESCRIPTION
My previous patch for GHC 7.8 actually broke it for 7.6 and earlier -- much apologies. I forgot that technically the `unsafePerformIO` in `System.IO.Unsafe` is a different function from the one in `Foreign`, because the one in `Foreign` is a wrapper that adds a deprecation warning, see http://hackage.haskell.org/package/base-4.6.0.0/docs/src/Foreign.html

This patch uses CPP to only use the newer location if on base 4.7 (which removed the one in `Foreign`).
