### PR TITLE
Fix for GHC 7.10

### DIFF
--- a/property-list.cabal
+++ b/property-list.cabal
@@ -45,12 +45,12 @@ Library
                         containers, 
                         free >= 1.8,
                         transformers,
-                        old-locale,
                         oneOfN,
                         recursion-schemes >= 1.8,
                         syb,
                         template-haskell,
                         text,
                         time,
+                        time-locale-compat,
                         vector,
                         xml >= 1.3.9

--- a/src/Data/PropertyList/Xml/Algebra.hs
+++ b/src/Data/PropertyList/Xml/Algebra.hs
@@ -13,7 +13,7 @@ import Data.Functor.Identity
 import qualified Data.Map as M
 import Data.PropertyList.Algebra
 import Data.Time
-import System.Locale
+import Data.Time.Locale.Compat
 import Text.XML.Light
 
 -- "%FT%T%QZ" would be better, but apple's plist parser


### PR DESCRIPTION
Quick fix for this incompatibility: https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10#time-1.5.0.1

I even tested this time that it doesn't break older versions horribly! Specifically I compiled successfully with GHC 7.4.1.
